### PR TITLE
Aanpassing in WAD_Processor:

### DIFF
--- a/WAD_Processor/src/wad_processor/CheckNewJobs.java
+++ b/WAD_Processor/src/wad_processor/CheckNewJobs.java
@@ -3,7 +3,12 @@
  * and open the template in the editor.
  */
 package wad_processor;
-
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.PreparedStatement;
+import java.sql.Types;
 import java.io.File;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -102,6 +107,12 @@ public class CheckNewJobs extends TimerTask {
 //                    input = input.replace("..", mainDir);
                     input = input.replace("/", File.separator);
 
+                    // output folder tbv logging per proces
+                    String outputFolder = ReadConfigXML.readFileElement("XML") + ReadFromIqcDatabase.getFilenameFromTable(dbConnection, "analysemodule_output", gp.getInputKey());
+                    outputFolder.replace("/", File.separator);
+                    outputFolder = outputFolder.substring(0,outputFolder.lastIndexOf(File.separator));
+                    p.set_outputFolder(outputFolder);
+
                     //controle op type extensie, zodat m-files, java-files etc de juiste commandline meekrijgen
                     //command[0] = "java -jar "+anaModuleFile + " \"" + input +"\"";
                     //command[1] = anaModuleFile + " " + input;
@@ -185,6 +196,7 @@ public class CheckNewJobs extends TimerTask {
         // aanpassen bij absoluut filepath voor XML in config.xml
         String output = ReadConfigXML.readFileElement("XML") + ReadFromIqcDatabase.getFilenameFromTable(dbConnection, "analysemodule_output", gp.getOutputKey());
         output = output.replace("/", File.separator);
+
         gp.updateStatus(dbConnection, 3);
         AnalyseModuleResultFile resultFile = new AnalyseModuleResultFile(output);
         Boolean succes = resultFile.read();
@@ -197,5 +209,29 @@ public class CheckNewJobs extends TimerTask {
             gp.updateStatus(dbConnection, 10);
         }
         
+        // voeg processor.log toe aan DB als object met volgnummer 999 op niveau 2
+        // FIXME: Hiermee wordt de logfile voor alle exit-statussen opgeslagen.
+        //        Als we deze alleen bij succes=false willen opslaan, deze routine bovenaan
+        //        de functie zetten.
+        String outputFolder = output.substring(0,output.lastIndexOf(File.separator));
+        try {
+            PreparedStatement pstmt = dbConnection.prepareStatement("INSERT INTO resultaten_object("
+                + "niveau, "
+                + "gewenste_processen_fk, "
+                + "omschrijving, "
+                + "volgnummer, "
+                + "object_naam_pad) "
+                + "values (?,?,?,?,?)");
+            pstmt.setString(1, "2");
+            pstmt.setInt(2, Integer.parseInt(gp.getKey()));
+            pstmt.setString(3, "processor.log");
+            pstmt.setString(4, "999");
+            pstmt.setString(5, outputFolder+File.separator+"processor.log");
+            pstmt.executeUpdate();
+            pstmt.close();
+        } catch (SQLException ex) {
+            log.error(ex);
+        }
+
     }
 }

--- a/WAD_Processor/src/wad_processor/CheckNewJobs.java
+++ b/WAD_Processor/src/wad_processor/CheckNewJobs.java
@@ -109,7 +109,7 @@ public class CheckNewJobs extends TimerTask {
 
                     // output folder tbv logging per proces
                     String outputFolder = ReadConfigXML.readFileElement("XML") + ReadFromIqcDatabase.getFilenameFromTable(dbConnection, "analysemodule_output", gp.getInputKey());
-                    outputFolder.replace("/", File.separator);
+                    outputFolder = outputFolder.replace("/", File.separator);
                     outputFolder = outputFolder.substring(0,outputFolder.lastIndexOf(File.separator));
                     p.set_outputFolder(outputFolder);
 

--- a/WAD_Processor/src/wad_processor/WAD_ProcessThread.java
+++ b/WAD_Processor/src/wad_processor/WAD_ProcessThread.java
@@ -8,6 +8,7 @@ import java.io.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+
 /**
  *
  * @author titulaer
@@ -25,6 +26,7 @@ public class WAD_ProcessThread extends Thread {
     private boolean _error = false;
     private String[] _args;
     private Process _proc;
+    private String _outputFolder;
     //Runtime rt = Runtime.getRuntime();
 
     public boolean isRunning() {
@@ -62,12 +64,15 @@ public class WAD_ProcessThread extends Thread {
             _proc = builder.start();
             //BT alleen wachten indien geconfigureerd, bijv html pagina openen kan reden zijn dat neit te doen
             BufferedReader reader = new BufferedReader(new InputStreamReader(_proc.getInputStream()));
+            FileWriter writer = new FileWriter(_outputFolder + File.separator + "processor.log");
             String line;
             while ((line = reader.readLine()) != null) {
                 // JK terminal output van tread naar logfile ipv stdout
                 //System.out.println("tasklist: " + line);
                 log.info("Thread " + _ID + ": " + line);
+                writer.write(line + "\n");
             }
+            writer.close();
             _proc.waitFor();
             //doc: Zet de parameter die aangeeft dat process klaar 
             _running = false;
@@ -111,4 +116,9 @@ public class WAD_ProcessThread extends Thread {
         return result;
 
     }
+
+    public void set_outputFolder(String outputfolder) {
+        this._outputFolder = outputfolder;
+    }
+
 }

--- a/WAD_Processor/src/wad_processor/WAD_Processor.java
+++ b/WAD_Processor/src/wad_processor/WAD_Processor.java
@@ -26,7 +26,7 @@ public class WAD_Processor {
     private static Log log = LogFactory.getLog(WAD_Processor.class);
     private static Properties logProperties = new Properties();
     //Versie van de Processor dient hardcoded in onderstaande regel opgenomen te worden.
-    private static String version= "1.0.0";
+    private static String version= "1.0.2";
 
     private WAD_Processor() {
         processListTimer = new Timer();

--- a/WAD_Selector/src/selector/Selector.java
+++ b/WAD_Selector/src/selector/Selector.java
@@ -502,24 +502,23 @@ public class Selector {
             String columnLabel = columnList.get(j);
             String selectorSeriesValue = selectorSeriesMap.get(columnLabel);
             String seriesValue = seriesMap.get(columnLabel);
-            if (!(selectorSeriesValue==null || seriesValue==null)){
-                if (!selectorSeriesValue.equalsIgnoreCase("null") && !selectorSeriesValue.equalsIgnoreCase("")){
-                    if (!columnLabel.equalsIgnoreCase("availability") && 
-                        !columnLabel.equalsIgnoreCase("series_status") && 
-                        !columnLabel.equalsIgnoreCase("pk") &&
-                        !columnLabel.equalsIgnoreCase("pps_start") &&    
-                        !columnLabel.equalsIgnoreCase("created_time") &&
-                        !columnLabel.equalsIgnoreCase("updated_time")     
-                            ){
-                        //if (!selectorSeriesValue.equalsIgnoreCase(seriesValue)){
-                        //    match=false;
-                        //}
-			seriesValue = Pattern.quote(seriesValue);
-                        if (!selectorSeriesValue.matches("(?i:(^|(.*;))\\s*"+seriesValue+"\\s*((;.*|$)))")){
-                            match=false;
-                        }
-                    }
-                }
+            if (!(selectorSeriesValue==null || selectorSeriesValue.equalsIgnoreCase("null") || selectorSeriesValue.equalsIgnoreCase(""))) {
+               if(seriesValue==null || seriesValue.equalsIgnoreCase("")){
+                   match=false;
+               } else {
+                   if (!columnLabel.equalsIgnoreCase("availability") && 
+                       !columnLabel.equalsIgnoreCase("series_status") && 
+                       !columnLabel.equalsIgnoreCase("pk") &&
+                       !columnLabel.equalsIgnoreCase("pps_start") &&    
+                       !columnLabel.equalsIgnoreCase("created_time") &&
+                       !columnLabel.equalsIgnoreCase("updated_time")     
+                      ) {
+                           seriesValue = Pattern.quote(seriesValue);
+                           if (!selectorSeriesValue.matches("(?i:(^|(.*;))\\s*"+seriesValue+"\\s*((;.*|$)))")){
+                              match=false;
+                           }
+                   }
+               }
             }
         }
         return match; 
@@ -528,30 +527,28 @@ public class Selector {
     private boolean isEqualStudyHashmaps(HashMap<String, String> selectorStudyMap, HashMap<String, String> studyMap){
         //Maak een lijst van de kolommen uit selector_series om te doorlopen een vergelijken
         ArrayList<String> columnList = getColomnNamesFromTable("selector_study");
-        Boolean match = true;            
+        Boolean match = true;
         for (int j=0;j<columnList.size();j++){
             String columnLabel = columnList.get(j);
             String selectorStudyValue = selectorStudyMap.get(columnLabel);
             String studyValue = studyMap.get(columnLabel);
-            if (!(selectorStudyValue==null || studyValue==null)){
-                if (!selectorStudyValue.equalsIgnoreCase("null") && !selectorStudyValue.equalsIgnoreCase("")){
-                    if (!columnLabel.equalsIgnoreCase("availability") && 
-                        !columnLabel.equalsIgnoreCase("study_status") && 
-                        !columnLabel.equalsIgnoreCase("study_datetime") && 
-                        !columnLabel.equalsIgnoreCase("pk") && 
-                        !columnLabel.equalsIgnoreCase("checked_time") && 
-                        !columnLabel.equalsIgnoreCase("updated_time") && 
-                        !columnLabel.equalsIgnoreCase("created_time")
-                            ){
-                        //if (!selectorStudyValue.equalsIgnoreCase(studyValue)){
-                        //    match=false;
-                        //}
-			studyValue = Pattern.quote(studyValue);
-                        if (!selectorStudyValue.matches("(?i:(^|(.*;))\\s*"+studyValue+"\\s*((;.*|$)))")){
-                            match=false;
-                        }
-                    }
-                }
+            if (!(selectorStudyValue==null || selectorStudyValue.equalsIgnoreCase("null") || selectorStudyValue.equalsIgnoreCase(""))) {
+               if (studyValue==null || studyValue.equalsIgnoreCase("")){
+                  match=false;
+               } else {
+                  if (!columnLabel.equalsIgnoreCase("availability") && 
+                      !columnLabel.equalsIgnoreCase("study_status") && 
+                      !columnLabel.equalsIgnoreCase("study_datetime") && 
+                      !columnLabel.equalsIgnoreCase("pk") && 
+                      !columnLabel.equalsIgnoreCase("checked_time") && 
+                      !columnLabel.equalsIgnoreCase("updated_time") && 
+                      !columnLabel.equalsIgnoreCase("created_time")
+                     ) {
+                          if (!selectorStudyValue.matches("(?i:(^|(.*;))\\s*"+studyValue+"\\s*((;.*|$)))")){
+                              match=false;
+                          }
+                  }
+               }
             }
         }
         return match; 
@@ -563,25 +560,24 @@ public class Selector {
         Boolean match = true;
         for (int j=0;j<columnList.size();j++){
             String columnLabel = columnList.get(j);
-            String selectorSeriesValue = selectorPatientMap.get(columnLabel);
-            String seriesValue = patientMap.get(columnLabel);
-            if (!(selectorSeriesValue==null || seriesValue==null)){
-                if (!selectorSeriesValue.equalsIgnoreCase("null") && !selectorSeriesValue.equalsIgnoreCase("")){
-                    if (!columnLabel.equalsIgnoreCase("pk") && 
-                        !columnLabel.equalsIgnoreCase("merge_fk") &&                          
-                        !columnLabel.equalsIgnoreCase("created_time") &&
-                        !columnLabel.equalsIgnoreCase("updated_time") &&
-                        !columnLabel.equalsIgnoreCase("pat_attrs")    
-                            ){
-                        //if (!selectorSeriesValue.equalsIgnoreCase(seriesValue)){
-                        //    match=false;
-                        //}
-			seriesValue = Pattern.quote(seriesValue);
-                        if (!selectorSeriesValue.matches("(?i:(^|(.*;))\\s*"+seriesValue+"\\s*((;.*|$)))")){
-                            match=false;
-                        }
-                    }
-                }
+            String selectorPatientValue = selectorPatientMap.get(columnLabel);
+            String patientValue = patientMap.get(columnLabel);
+            if (!(selectorPatientValue==null || selectorPatientValue.equalsIgnoreCase("null") || selectorPatientValue.equalsIgnoreCase(""))) {
+               if (patientValue==null || patientValue.equalsIgnoreCase("")) {
+                  match=false;
+               } else {
+                  if (!columnLabel.equalsIgnoreCase("pk") && 
+                      !columnLabel.equalsIgnoreCase("merge_fk") &&                          
+                      !columnLabel.equalsIgnoreCase("created_time") &&
+                      !columnLabel.equalsIgnoreCase("updated_time") &&
+                      !columnLabel.equalsIgnoreCase("pat_attrs")    
+                     ) {
+                          patientValue = Pattern.quote(patientValue);
+                          if (!selectorPatientValue.matches("(?i:(^|(.*;))\\s*"+patientValue+"\\s*((;.*|$)))")){
+                             match=false;
+                          }
+                  }
+               }
             }
         }
         return match; 
@@ -593,30 +589,29 @@ public class Selector {
         Boolean match = true;
         for (int j=0;j<columnList.size();j++){
             String columnLabel = columnList.get(j);
-            String selectorSeriesValue = selectorInstanceMap.get(columnLabel);
-            String seriesValue = instanceMap.get(columnLabel);
-            if (!(selectorSeriesValue==null || seriesValue==null)){
-                if (!selectorSeriesValue.equalsIgnoreCase("null") && !selectorSeriesValue.equalsIgnoreCase("")){
-                    if (!columnLabel.equalsIgnoreCase("pk") && 
-                        !columnLabel.equalsIgnoreCase("content_datetime") &&  
-                        !columnLabel.equalsIgnoreCase("availability") &&
-                        !columnLabel.equalsIgnoreCase("inst_status") &&
-                        !columnLabel.equalsIgnoreCase("all_attrs") &&
-                        !columnLabel.equalsIgnoreCase("commitment") &&
-                        !columnLabel.equalsIgnoreCase("archived") &&
-                        !columnLabel.equalsIgnoreCase("created_time") &&
-                        !columnLabel.equalsIgnoreCase("updated_time") &&
-                        !columnLabel.equalsIgnoreCase("inst_attrs")     
-                            ){
-                        //if (!selectorSeriesValue.equals(seriesValue)){
-                        //    match=false;
-                        //}
-			seriesValue = Pattern.quote(seriesValue);
-                        if (!selectorSeriesValue.matches("(?i:(^|(.*;))\\s*"+seriesValue+"\\s*((;.*|$)))")){
-                            match=false;
-                        }
-                    }
-                }
+            String selectorInstanceValue = selectorInstanceMap.get(columnLabel);
+            String instanceValue = instanceMap.get(columnLabel);
+            if (!(selectorInstanceValue==null || selectorInstanceValue.equalsIgnoreCase("null") || selectorInstanceValue.equalsIgnoreCase(""))) {
+               if (instanceValue==null || instanceValue.equalsIgnoreCase("")) {
+                  match=false;
+               } else {
+                  if (!columnLabel.equalsIgnoreCase("pk") &&
+                      !columnLabel.equalsIgnoreCase("content_datetime") &&
+                      !columnLabel.equalsIgnoreCase("availability") &&
+                      !columnLabel.equalsIgnoreCase("inst_status") &&
+                      !columnLabel.equalsIgnoreCase("all_attrs") &&
+                      !columnLabel.equalsIgnoreCase("commitment") &&
+                      !columnLabel.equalsIgnoreCase("archived") &&
+                      !columnLabel.equalsIgnoreCase("created_time") &&
+                      !columnLabel.equalsIgnoreCase("updated_time") &&
+                      !columnLabel.equalsIgnoreCase("inst_attrs")
+                     ) {
+                          instanceValue = Pattern.quote(instanceValue);
+                          if (!selectorInstanceValue.matches("(?i:(^|(.*;))\\s*"+instanceValue+"\\s*((;.*|$)))")) {
+                              match=false;
+                          }
+                  }
+               }
             }
         }
         return match; 

--- a/WAD_Selector/src/selector/Selector.java
+++ b/WAD_Selector/src/selector/Selector.java
@@ -514,7 +514,7 @@ public class Selector {
                        !columnLabel.equalsIgnoreCase("updated_time")     
                       ) {
                            seriesValue = Pattern.quote(seriesValue);
-                           if (!selectorSeriesValue.matches("(?i:(^|(.*;))\\s*"+seriesValue+"\\s*((;.*|$)))")){
+                           if (!matches(seriesValue,selectorSeriesValue)) {
                               match=false;
                            }
                    }
@@ -544,7 +544,7 @@ public class Selector {
                       !columnLabel.equalsIgnoreCase("updated_time") && 
                       !columnLabel.equalsIgnoreCase("created_time")
                      ) {
-                          if (!selectorStudyValue.matches("(?i:(^|(.*;))\\s*"+studyValue+"\\s*((;.*|$)))")){
+                          if (!matches(studyValue,selectorStudyValue)) {
                               match=false;
                           }
                   }
@@ -573,7 +573,7 @@ public class Selector {
                       !columnLabel.equalsIgnoreCase("pat_attrs")    
                      ) {
                           patientValue = Pattern.quote(patientValue);
-                          if (!selectorPatientValue.matches("(?i:(^|(.*;))\\s*"+patientValue+"\\s*((;.*|$)))")){
+                          if (!matches(patientValue,selectorPatientValue)) {
                              match=false;
                           }
                   }
@@ -607,7 +607,7 @@ public class Selector {
                       !columnLabel.equalsIgnoreCase("inst_attrs")
                      ) {
                           instanceValue = Pattern.quote(instanceValue);
-                          if (!selectorInstanceValue.matches("(?i:(^|(.*;))\\s*"+instanceValue+"\\s*((;.*|$)))")) {
+                          if (!matches(instanceValue,selectorInstanceValue)) {
                               match=false;
                           }
                   }
@@ -698,4 +698,25 @@ public class Selector {
         }
         return null;
     }
+
+
+    // text = te doorzoeken string
+    // pattern = zoekpatroon, bestaande uit een ";" gescheiden string met
+    //           zoekparameters, waarbij de wildcards * en ? worden ondersteund
+    //           en leading/trailing spaties worden genegeerd.
+    //           bijv: "*Uniformity* ; *QC*"
+    // Matching gebeurt case-insensitive!
+    // Functie geeft "true" terug als er bij minimaal 1 zoekparameter een match is.
+    private static boolean matches(String text, String pattern)
+    {
+        boolean searchmatch = false;
+        String[] searchparams = pattern.split(";");
+        for (String param: searchparams)
+        {
+           param = param.trim();
+           searchmatch = searchmatch || text.matches("(?i)"+param.replace("?", ".?").replace("*", ".*?"));
+        }
+        return searchmatch;
+    }
+
 }

--- a/WAD_Selector/src/selector/Selector.java
+++ b/WAD_Selector/src/selector/Selector.java
@@ -513,7 +513,6 @@ public class Selector {
                        !columnLabel.equalsIgnoreCase("created_time") &&
                        !columnLabel.equalsIgnoreCase("updated_time")     
                       ) {
-                           seriesValue = Pattern.quote(seriesValue);
                            if (!matches(seriesValue,selectorSeriesValue)) {
                               match=false;
                            }
@@ -572,7 +571,6 @@ public class Selector {
                       !columnLabel.equalsIgnoreCase("updated_time") &&
                       !columnLabel.equalsIgnoreCase("pat_attrs")    
                      ) {
-                          patientValue = Pattern.quote(patientValue);
                           if (!matches(patientValue,selectorPatientValue)) {
                              match=false;
                           }
@@ -606,7 +604,6 @@ public class Selector {
                       !columnLabel.equalsIgnoreCase("updated_time") &&
                       !columnLabel.equalsIgnoreCase("inst_attrs")
                      ) {
-                          instanceValue = Pattern.quote(instanceValue);
                           if (!matches(instanceValue,selectorInstanceValue)) {
                               match=false;
                           }


### PR DESCRIPTION
Deze schrijft nu per gewenst proces een logfile weg in de result-folder en importeert deze als object in de DB op niveau 2, met volgnummer 999 om conflicten te voorkomen.
Met een aanpassing in de Interface wordt het mogelijk om deze logfiles te openen vanaf de Processor-status pagina.