### PR TITLE
bugfix voor  Column 'created_time' specified twice als rsRead meerdere regels bevat

### DIFF
--- a/WAD_Collector/src/wad/db/WriteToIqcDatabase.java
+++ b/WAD_Collector/src/wad/db/WriteToIqcDatabase.java
@@ -37,6 +37,8 @@ public class WriteToIqcDatabase {
             ResultSetMetaData rsWriteMetaData = rsRead.getMetaData();
             int nrOfColomns = rsWriteMetaData.getColumnCount();
             while (rsRead.next()){
+               sqlColomn = "";
+               sqlValues = "";
                 for (int i=1;i<=nrOfColomns;i++){
                     if (!sqlColomn.equals("")){
                         sqlColomn = sqlColomn+", ";


### PR DESCRIPTION
als rsRead meerdere regels bevat dan wordt een foutief sql commando gemaakt, resulterend in:
com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Column 'created_time' specified twice

