### PR TITLE
Fixt probleem met quotes rondom het input.xml pad.

### DIFF
--- a/WAD_Processor/src/wad_processor/CheckNewJobs.java
+++ b/WAD_Processor/src/wad_processor/CheckNewJobs.java
@@ -121,7 +121,7 @@ public class CheckNewJobs extends TimerTask {
                         command[0] = "java";
                         command[1] = "-jar";
                         command[2] = anaModuleFile;
-                        command[3] = "\"" + input + "\"";
+                        command[3] = input;
 		    } else if (matchExtension(anaModuleFile, "py")) {
                         command = new String[3];
                         command[0] = "python";
@@ -135,7 +135,7 @@ public class CheckNewJobs extends TimerTask {
 		    } else {
                         command = new String[2];
                         command[0] = anaModuleFile;
-                        command[1] = "\"" + input + "\"";
+                        command[1] = input;
                     }
 
 


### PR DESCRIPTION
Windows kan hier prima mee overweg, maar linux niet.
Beide OS-es hebben deze blijkbaar niet nodig.
Quotes stonden al uit voor de python extensie, vandaar
dat het probleem pas recent aan het licht is gekomen.

Svp even goed testen met verschillende modules en dan mag ie worden gemerged...